### PR TITLE
SystemUI: Fix summary of hotspot toggle

### DIFF
--- a/packages/SystemUI/res/values/cr_strings.xml
+++ b/packages/SystemUI/res/values/cr_strings.xml
@@ -137,8 +137,8 @@
     <string name="tristate_rotation_270">Landscape (270°)</string>
 
     <!-- QuickSettings: InternetDialog: Summary for how many devices are connected to the hotspot [CHAR LIMIT=NONE] -->
-    <plurals name="quick_settings_internet_hotspot_summary_num_devices">
-        <item quantity="one">%d device connected</item>
-        <item quantity="other">%d devices connected</item>
-    </plurals>
+    <string name="quick_settings_internet_hotspot_summary_num_devices">{count, plural,
+        =1 {# device connected}
+        other {# devices connected}
+    }</string>
 </resources>


### PR DESCRIPTION
* fix build broken by 480128f6bc0179942e4551b3d63634c8c0559da4
* use `string` instead of `plurals` like 1cc5e51e83a5de1b5cbfc7260e2fddbdafad12a6